### PR TITLE
Fix CVE-2021-43138 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "test:coverage": "NODE_ENV=test ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --print both -- --opts tests/mocha.opts -R spec ./tests"
   },
   "dependencies": {
-    "async": "2.6.0",
+    "async": "^3.2.4",
     "lodash": "^4.17.10",
-    "rr": "0.1.0"
+    "rr": "^0.1.0"
   },
   "devDependencies": {
     "chai": "4.1.2",


### PR DESCRIPTION
Fix CVE-2021-43138 error. Upgrade dependencies versions